### PR TITLE
feat: kazuto 投稿文ジェネレーターアプリ（スマホ対応）

### DIFF
--- a/.github/workflows/kazuto_post.yml
+++ b/.github/workflows/kazuto_post.yml
@@ -1,0 +1,51 @@
+name: kazuto X Auto Post
+
+on:
+  schedule:
+    # 07:00 JST (UTC 22:00 前日)
+    - cron: "0 22 * * *"
+    # 12:00 JST (UTC 03:00)
+    - cron: "0 3 * * *"
+    # 17:00 JST (UTC 08:00)
+    - cron: "0 8 * * *"
+    # 21:00 JST (UTC 12:00)
+    - cron: "0 12 * * *"
+    # 23:00 JST (UTC 14:00)
+    - cron: "0 14 * * *"
+  workflow_dispatch:
+
+jobs:
+  post:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run auto post (kazuto)
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          X_API_KEY: ${{ secrets.KAZUTO_X_API_KEY }}
+          X_API_SECRET: ${{ secrets.KAZUTO_X_API_SECRET }}
+          X_ACCESS_TOKEN: ${{ secrets.KAZUTO_X_ACCESS_TOKEN }}
+          X_ACCESS_SECRET: ${{ secrets.KAZUTO_X_ACCESS_SECRET }}
+        run: python src/main.py --persona persona/kazuto_config.yaml
+
+      - name: Commit post history
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add posts/kazuto_history.json posts/queue.json || true
+          git diff --staged --quiet || git commit -m "chore: update kazuto post history [skip ci]"
+          git push || true

--- a/persona/kazuto_config.yaml
+++ b/persona/kazuto_config.yaml
@@ -188,6 +188,7 @@ avoid:
 max_length: 140
 add_hashtags: true
 max_hashtags: 2
+history_file: "posts/kazuto_history.json"
 
 # =============================================
 # プラットフォーム設定

--- a/render.yaml
+++ b/render.yaml
@@ -1,6 +1,6 @@
 services:
   - type: web
-    name: kazuto-post-manager
+    name: kazuto-post-generator
     runtime: python
     buildCommand: pip install -r requirements.txt
     startCommand: gunicorn src.web_app:app --bind 0.0.0.0:$PORT --workers 1 --timeout 120
@@ -8,19 +8,5 @@ services:
     envVars:
       - key: WEB_PASSWORD
         sync: false          # ログインパスワード（任意の文字列を設定）
-      - key: GITHUB_TOKEN
-        sync: false          # GitHub PAT (Settings→Developer settings→PAT→contents:write)
-      - key: GITHUB_REPO
-        value: "eternaldct-png/-"
-      - key: GITHUB_BRANCH
-        value: "main"
       - key: ANTHROPIC_API_KEY
-        sync: false          # 投稿生成に必要
-      - key: X_API_KEY
-        sync: false          # X への投稿に必要
-      - key: X_API_SECRET
-        sync: false
-      - key: X_ACCESS_TOKEN
-        sync: false
-      - key: X_ACCESS_SECRET
-        sync: false
+        sync: false          # 投稿文生成に必要

--- a/src/main.py
+++ b/src/main.py
@@ -2,15 +2,16 @@
 マルチプラットフォーム自動投稿 メインオーケストレーター
 
 使い方:
-  python src/main.py                          # X に投稿（デフォルト）
-  python src/main.py --platform instagram     # Instagram に投稿
-  python src/main.py --platform note          # note 記事を生成
-  python src/main.py --platform tiktok        # TikTok スクリプトを生成
-  python src/main.py --dry-run                # プレビューのみ（投稿しない）
-  python src/main.py --generate               # 生成のみ表示（投稿しない）
-  python src/main.py --benchmark              # ベンチマーク分析を実行
-  python src/main.py --update-persona         # ペルソナ更新案を生成・確認
-  python src/main.py --update-persona --auto  # ペルソナを確認なしで自動更新
+  python src/main.py                                      # X に投稿（デフォルト）
+  python src/main.py --persona persona/kazuto_config.yaml # kazuto ペルソナで投稿
+  python src/main.py --platform instagram                 # Instagram に投稿
+  python src/main.py --platform note                      # note 記事を生成
+  python src/main.py --platform tiktok                    # TikTok スクリプトを生成
+  python src/main.py --dry-run                            # プレビューのみ（投稿しない）
+  python src/main.py --generate                           # 生成のみ表示（投稿しない）
+  python src/main.py --benchmark                          # ベンチマーク分析を実行
+  python src/main.py --update-persona                     # ペルソナ更新案を生成・確認
+  python src/main.py --update-persona --auto              # ペルソナを確認なしで自動更新
   python src/main.py --platform note --dry-run
 """
 import sys
@@ -47,10 +48,10 @@ def load_persona(config_path: str = "persona/config.yaml") -> dict:
         return yaml.safe_load(f)
 
 
-def run(dry_run: bool = False, generate_only: bool = False, platform: str = "x") -> None:
+def run(dry_run: bool = False, generate_only: bool = False, platform: str = "x", persona_path: str = "persona/config.yaml") -> None:
     """メイン処理"""
     print(f"[main] ペルソナ設定を読み込み中...")
-    persona = load_persona()
+    persona = load_persona(persona_path)
     print(f"[main] ペルソナ: {persona['name']} | プラットフォーム: {platform.upper()}")
 
     adapters = _get_platform_adapters()
@@ -58,7 +59,7 @@ def run(dry_run: bool = False, generate_only: bool = False, platform: str = "x")
         print(f"[main] エラー: 未対応のプラットフォーム '{platform}'。対応: {list(adapters.keys())}")
         sys.exit(1)
 
-    adapter = adapters[platform]()
+    adapter = adapters[platform](persona=persona)
     constraints = adapter.get_constraints()
 
     # キューに該当プラットフォームの投稿があればそちらを優先
@@ -198,6 +199,11 @@ if __name__ == "__main__":
         default="x",
         help="投稿先プラットフォーム（デフォルト: x）",
     )
+    parser.add_argument(
+        "--persona",
+        default="persona/config.yaml",
+        help="ペルソナ設定ファイルのパス（デフォルト: persona/config.yaml）",
+    )
     parser.add_argument("--dry-run", action="store_true", help="プレビューのみ（実際には投稿しない）")
     parser.add_argument("--generate", action="store_true", help="生成のみ表示（投稿しない）")
     parser.add_argument("--benchmark", action="store_true", help="ベンチマーク分析を実行")
@@ -212,4 +218,4 @@ if __name__ == "__main__":
         from persona_updater import run_update
         run_update(auto=args.auto)
     else:
-        run(dry_run=args.dry_run, generate_only=args.generate, platform=args.platform)
+        run(dry_run=args.dry_run, generate_only=args.generate, platform=args.platform, persona_path=args.persona)

--- a/src/platforms/base.py
+++ b/src/platforms/base.py
@@ -9,6 +9,9 @@ from pathlib import Path
 class PlatformAdapter(ABC):
     """全投稿プラットフォームの共通インターフェース"""
 
+    def __init__(self, persona: dict = None):
+        self._persona = persona or {}
+
     @abstractmethod
     def post(self, content: dict, dry_run: bool = False) -> dict:
         """

--- a/src/platforms/x.py
+++ b/src/platforms/x.py
@@ -18,7 +18,12 @@ HISTORY_PATH = Path("posts/x_history.json")
 class XAdapter(PlatformAdapter):
     """X（Twitter）投稿アダプター"""
 
+    def __init__(self, persona: dict = None):
+        self._persona = persona or {}
+
     def get_history_path(self) -> Path:
+        if self._persona.get("history_file"):
+            return Path(self._persona["history_file"])
         return HISTORY_PATH
 
     def get_constraints(self) -> dict:

--- a/src/web_app.py
+++ b/src/web_app.py
@@ -1,38 +1,24 @@
 """
-投稿管理ダッシュボード — スマホ対応Webアプリ
-URLを開くだけでキューの確認・編集・即時投稿ができる
+kazuto 投稿文ジェネレーター — スマホ対応Webアプリ
 
-機能:
-  - 未投稿/投稿済タブ表示
-  - 手動で投稿文を追加（ボトムシート）
-  - テキスト編集（リアルタイム文字数カウント）
-  - スケジュール時刻変更
-  - X への即時投稿
-  - プラットフォームフィルタ（X / Instagram / note）
-  - テキストコピー
-  - テーマ指定 + 件数指定で生成（1 / 3 / 5件）
+スマホで開いてボタンを押すだけで投稿文を生成し、コピーできる。
+自動投稿なし。X API 不要。
 """
 import os
 import sys
-import json
 import base64
 from pathlib import Path
-from datetime import datetime, timedelta
 from functools import wraps
-from zoneinfo import ZoneInfo
 from flask import Flask, request, jsonify, Response
 
 sys.path.insert(0, str(Path(__file__).parent))
 
-from github_storage import storage as _storage
-
-JST = ZoneInfo("Asia/Tokyo")
 WEB_PASSWORD = os.environ.get("WEB_PASSWORD", "kazuto")
 
 app = Flask(__name__)
 
 
-# ── 認証 ─────────────────────────────────────────────────────
+# ── 認証 ──────────────────────────────────────────────────────────
 
 def _check_auth() -> bool:
     auth = request.headers.get("Authorization", "")
@@ -53,171 +39,30 @@ def require_auth(f):
             return Response(
                 "認証が必要です",
                 401,
-                {"WWW-Authenticate": 'Basic realm="kazuto投稿管理"'},
+                {"WWW-Authenticate": 'Basic realm="kazuto投稿ジェネレーター"'},
             )
         return f(*args, **kwargs)
     return decorated
 
 
-# ── キュー操作（GitHub API 経由で永続化）─────────────────────
-
-def _load_queue() -> list[dict]:
-    return _storage.read()
-
-
-def _save_queue(queue: list[dict]) -> None:
-    _storage.write(queue)
-
-
-def _find_index(queue: list[dict], item_id: str) -> int:
-    for i, item in enumerate(queue):
-        if item.get("created_at") == item_id:
-            return i
-    return -1
-
-
-# ── API エンドポイント ─────────────────────────────────────────
-
-@app.route("/api/queue")
-@require_auth
-def api_queue():
-    """全キューを返す（_id = created_at を付与）"""
-    queue = _load_queue()
-    for item in queue:
-        item["_id"] = item.get("created_at", "")
-    return jsonify(queue)
-
-
-@app.route("/api/add", methods=["POST"])
-@require_auth
-def api_add():
-    """投稿文を手動でキューに追加する"""
-    data = request.get_json(force=True)
-    text = data.get("text", "").strip()
-    platform = data.get("platform", "x")
-    scheduled_for = data.get("scheduled_for", "")
-
-    if not text:
-        return jsonify({"error": "テキストが空です"}), 400
-
-    now = datetime.now(JST)
-    if not scheduled_for:
-        # デフォルト: 1時間後
-        scheduled_for = (now + timedelta(hours=1)).isoformat()
-
-    entry = {
-        "text": text,
-        "platform": platform,
-        "scheduled_for": scheduled_for,
-        "status": "pending",
-        "created_at": now.isoformat(),
-        "posted_at": None,
-        "manually_added": True,
-    }
-    queue = _load_queue()
-    queue.append(entry)
-    _save_queue(queue)
-    entry["_id"] = entry["created_at"]
-    return jsonify({"ok": True, "item": entry})
-
-
-@app.route("/api/edit", methods=["POST"])
-@require_auth
-def api_edit():
-    """投稿テキストを編集する"""
-    data = request.get_json(force=True)
-    item_id = data.get("id", "")
-    new_text = data.get("text", "").strip()
-
-    queue = _load_queue()
-    idx = _find_index(queue, item_id)
-    if idx == -1:
-        return jsonify({"error": "投稿が見つかりません"}), 404
-
-    queue[idx]["text"] = new_text
-    queue[idx]["edited_at"] = datetime.now(JST).isoformat()
-    _save_queue(queue)
-    return jsonify({"ok": True, "length": len(new_text)})
-
-
-@app.route("/api/reschedule", methods=["POST"])
-@require_auth
-def api_reschedule():
-    """投稿のスケジュール時刻を変更する"""
-    data = request.get_json(force=True)
-    item_id = data.get("id", "")
-    new_time = data.get("scheduled_for", "")
-
-    if not new_time:
-        return jsonify({"error": "時刻が指定されていません"}), 400
-
-    queue = _load_queue()
-    idx = _find_index(queue, item_id)
-    if idx == -1:
-        return jsonify({"error": "投稿が見つかりません"}), 404
-
-    queue[idx]["scheduled_for"] = new_time
-    # 一度 expired になっていた場合は pending に戻す
-    if queue[idx].get("status") == "expired":
-        queue[idx]["status"] = "pending"
-    _save_queue(queue)
-    return jsonify({"ok": True})
-
-
-@app.route("/api/delete", methods=["POST"])
-@require_auth
-def api_delete():
-    """投稿をキューから削除する"""
-    data = request.get_json(force=True)
-    item_id = data.get("id", "")
-    queue = _load_queue()
-    before = len(queue)
-    queue = [item for item in queue if item.get("created_at") != item_id]
-    _save_queue(queue)
-    return jsonify({"ok": True, "deleted": before - len(queue)})
-
-
-@app.route("/api/post", methods=["POST"])
-@require_auth
-def api_post():
-    """指定の投稿を X に今すぐ投稿する"""
-    data = request.get_json(force=True)
-    item_id = data.get("id", "")
-    queue = _load_queue()
-    idx = _find_index(queue, item_id)
-    if idx == -1:
-        return jsonify({"error": "投稿が見つかりません"}), 404
-
-    item = queue[idx]
-    try:
-        from platforms.x import XAdapter
-        adapter = XAdapter()
-        result = adapter.post({"text": item["text"]}, dry_run=False)
-        pid = result.get("platform_id", "")
-        if pid and pid != "skipped_duplicate":
-            queue[idx]["status"] = "posted"
-            queue[idx]["posted_at"] = datetime.now(JST).isoformat()
-            _save_queue(queue)
-            return jsonify({"ok": True, "tweet_id": pid})
-        return jsonify({"error": "投稿に失敗しました（重複または API エラー）"}), 500
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
-
+# ── 生成 API ──────────────────────────────────────────────────────
 
 @app.route("/api/generate", methods=["POST"])
 @require_auth
 def api_generate():
-    """kazuto ペルソナで新規投稿を生成してキューに追加する"""
+    """投稿文を生成して返す（キュー保存・投稿なし）"""
+    import yaml
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
+    from research import build_research_context
+    from generate import generate_post
+
     data = request.get_json(force=True)
-    count = max(1, min(5, int(data.get("count", 3))))
-    theme = data.get("theme", "").strip()  # テーマ指定（任意）
+    count = max(1, min(5, int(data.get("count", 1))))
+    theme = data.get("theme", "").strip()
+    slot = data.get("slot", "")  # "朝" / "昼" / "夕方" / "夜" / "深夜"
 
     try:
-        import yaml
-        from research import build_research_context
-        from generate import generate_post
-        from queue_manager import add_to_queue
-
         persona_path = Path("persona/kazuto_config.yaml")
         if not persona_path.exists():
             persona_path = Path("persona/config.yaml")
@@ -225,10 +70,24 @@ def api_generate():
         with open(persona_path, "r", encoding="utf-8") as f:
             persona = yaml.safe_load(f)
 
+        JST = ZoneInfo("Asia/Tokyo")
+        now = datetime.now(JST)
+
+        # 時間帯 → 投稿スタイルのヒントを research context に乗せる
+        slot_hint = {
+            "朝":  "朝の一言。今日の意気込み・音楽への想いを短く。朝にふさわしいエネルギー。",
+            "昼":  "音楽・歌に関する深い話、好きな曲、歌い方のtips。音楽好きが反応したくなる内容。",
+            "夕方": "配信告知 または 事務所・ライバー関連。コミュニティ感・チーム感を出す。",
+            "夜":  "配信中・配信後レポート または フォロワーへの問いかけ。ライブ感・エンゲージメント重視。",
+            "深夜": "今日一日の締めくくり。感謝・振り返り。温かく短い言葉。",
+        }.get(slot, "")
+
         research = build_research_context(persona.get("interests", []))
-        preferred_hours = persona.get("posting_schedule", {}).get(
-            "preferred_hours", [7, 12, 17, 21, 23]
-        )
+        if theme:
+            research["theme_hint"] = theme
+        if slot_hint:
+            research["slot_hint"] = slot_hint
+
         constraints = {
             "max_length": 140,
             "max_hashtags": 2,
@@ -236,44 +95,28 @@ def api_generate():
             "content_format": "text",
         }
 
-        # テーマ指定がある場合、research context に追加
-        if theme:
-            research["theme_hint"] = theme
-
         posts = []
         recent = []
         for _ in range(count):
             text = generate_post(
-                persona, research, platform="x",
-                constraints=constraints, recent_posts=recent,
+                persona, research,
+                platform="x",
+                constraints=constraints,
+                recent_posts=recent,
             )
             if isinstance(text, str) and text.strip():
                 posts.append(text.strip())
                 recent.append(text.strip())
 
         if posts:
-            add_to_queue(posts, preferred_hours, platform="x")
-            return jsonify({"ok": True, "count": len(posts)})
-        return jsonify({"error": "生成に失敗しました"}), 500
+            return jsonify({"ok": True, "posts": posts})
+        return jsonify({"error": "生成に失敗しました。もう一度お試しください。"}), 500
+
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 
 
-@app.route("/api/status")
-@require_auth
-def api_status():
-    """キューのサマリーを返す"""
-    queue = _load_queue()
-    pending = [q for q in queue if q.get("status") == "pending"]
-    posted = [q for q in queue if q.get("status") == "posted"]
-    return jsonify({
-        "pending": len(pending),
-        "posted": len(posted),
-        "total": len(queue),
-    })
-
-
-# ── Web UI ─────────────────────────────────────────────────────
+# ── フロントエンド HTML ────────────────────────────────────────────
 
 HTML = r"""<!DOCTYPE html>
 <html lang="ja">
@@ -282,708 +125,508 @@ HTML = r"""<!DOCTYPE html>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-<meta name="theme-color" content="#0f0f23">
-<title>kazuto 投稿管理</title>
+<meta name="theme-color" content="#0d0d1f">
+<title>kazuto 投稿ジェネレーター</title>
 <style>
 :root {
-  --bg: #0f0f23;
-  --card: #1a1a3e;
-  --card2: #22224a;
-  --accent: #8b5cf6;
-  --accent2: #6d28d9;
+  --bg: #0d0d1f;
+  --surface: #181830;
+  --surface2: #21213d;
+  --accent: #7c3aed;
+  --accent-light: #a78bfa;
+  --accent-glow: rgba(124,58,237,0.25);
   --green: #10b981;
-  --yellow: #f59e0b;
-  --red: #ef4444;
-  --blue: #3b82f6;
   --text: #e2e8f0;
-  --muted: #94a3b8;
-  --border: #2d2d5e;
+  --muted: #8892a4;
+  --border: #2a2a4a;
   --safe-bottom: env(safe-area-inset-bottom, 0px);
 }
 * { box-sizing: border-box; margin: 0; padding: 0; -webkit-tap-highlight-color: transparent; }
+html, body { height: 100%; }
 body {
   background: var(--bg);
   color: var(--text);
-  font-family: -apple-system, BlinkMacSystemFont, 'Hiragino Sans', 'Yu Gothic', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Hiragino Sans', 'Yu Gothic UI', sans-serif;
   min-height: 100vh;
-  padding-bottom: calc(80px + var(--safe-bottom));
-  overscroll-behavior: none;
+  padding-bottom: calc(24px + var(--safe-bottom));
 }
 
 /* ── ヘッダー ── */
 .header {
-  background: var(--card);
+  background: var(--surface);
   border-bottom: 1px solid var(--border);
-  padding: 14px 16px 10px;
+  padding: 16px 18px 14px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
   position: sticky;
   top: 0;
-  z-index: 200;
+  z-index: 100;
 }
-.header-row { display: flex; justify-content: space-between; align-items: center; }
-.header h1 { font-size: 17px; font-weight: 700; }
-.header h1 span { color: var(--accent); }
-.badges { display: flex; gap: 6px; margin-top: 5px; }
-.badge { font-size: 11px; padding: 2px 9px; border-radius: 999px; font-weight: 600; }
-.badge-p { background: rgba(139,92,246,0.2); color: var(--accent); }
-.badge-d { background: rgba(16,185,129,0.2); color: var(--green); }
-.refresh-btn {
-  width: 32px; height: 32px;
-  background: var(--card2); border: none; border-radius: 8px;
-  color: var(--muted); cursor: pointer; font-size: 16px;
+.header-icon {
+  width: 38px; height: 38px;
+  background: linear-gradient(135deg, var(--accent), #5b21b6);
+  border-radius: 10px;
   display: flex; align-items: center; justify-content: center;
+  font-size: 20px; flex-shrink: 0;
+}
+.header-title { font-size: 17px; font-weight: 700; }
+.header-sub { font-size: 12px; color: var(--muted); margin-top: 1px; }
+
+/* ── メインコンテンツ ── */
+.main { padding: 18px 16px; max-width: 540px; margin: 0 auto; }
+
+/* ── セクションラベル ── */
+.section-label {
+  font-size: 11px; font-weight: 700; color: var(--muted);
+  letter-spacing: 0.08em; text-transform: uppercase;
+  margin-bottom: 8px;
 }
 
-/* ── タブ ── */
-.tabs {
-  display: flex;
-  background: var(--card);
-  border-bottom: 1px solid var(--border);
-  position: sticky;
-  top: 68px;
-  z-index: 199;
+/* ── 時間帯ボタン ── */
+.slot-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 6px;
+  margin-bottom: 18px;
 }
-.tab {
-  flex: 1; padding: 9px; text-align: center;
-  font-size: 13px; font-weight: 600; color: var(--muted);
-  cursor: pointer; border-bottom: 2px solid transparent; transition: all 0.2s;
-}
-.tab.active { color: var(--accent); border-bottom-color: var(--accent); }
-
-/* ── フィルタチップ ── */
-.filter-row {
-  display: flex; gap: 6px; padding: 10px 14px 0;
-  overflow-x: auto; -webkit-overflow-scrolling: touch; scrollbar-width: none;
-}
-.filter-row::-webkit-scrollbar { display: none; }
-.chip {
-  flex-shrink: 0; padding: 4px 12px;
-  border: 1px solid var(--border); border-radius: 999px;
-  background: transparent; color: var(--muted); font-size: 12px; font-weight: 600;
-  cursor: pointer; transition: all 0.15s;
-}
-.chip.active { background: var(--accent); border-color: var(--accent); color: white; }
-
-/* ── コンテナ ── */
-.container { padding: 10px 14px; max-width: 600px; margin: 0 auto; }
-
-/* ── 生成ボタンエリア ── */
-.gen-area { margin-bottom: 12px; }
-.gen-row { display: flex; gap: 8px; margin-bottom: 8px; }
-.gen-main {
-  flex: 1; padding: 12px;
-  background: linear-gradient(135deg, var(--accent), var(--accent2));
-  color: white; border: none; border-radius: 12px;
-  font-size: 14px; font-weight: 700; cursor: pointer;
-  display: flex; align-items: center; justify-content: center; gap: 6px;
-  transition: opacity 0.2s;
-}
-.gen-main:active { opacity: 0.8; }
-.gen-main:disabled { opacity: 0.5; cursor: not-allowed; }
-.gen-opts-btn {
-  padding: 12px 14px;
-  background: var(--card2); border: 1px solid var(--border);
-  border-radius: 12px; color: var(--muted); font-size: 18px;
+.slot-btn {
+  padding: 10px 4px 8px;
+  background: var(--surface);
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  color: var(--muted);
+  font-size: 12px; font-weight: 600;
   cursor: pointer;
+  display: flex; flex-direction: column;
+  align-items: center; gap: 3px;
+  transition: all 0.15s;
 }
+.slot-btn .slot-time { font-size: 10px; color: var(--muted); font-weight: 400; }
+.slot-btn.active {
+  background: var(--accent-glow);
+  border-color: var(--accent);
+  color: var(--accent-light);
+}
+.slot-btn.active .slot-time { color: var(--accent-light); opacity: 0.8; }
 
-/* 生成オプションパネル */
-.gen-panel {
-  background: var(--card); border: 1px solid var(--border); border-radius: 12px;
-  padding: 12px; display: none;
-}
-.gen-panel.open { display: block; }
-.gen-panel label { font-size: 11px; color: var(--muted); font-weight: 600; display: block; margin-bottom: 6px; }
-.count-row { display: flex; gap: 6px; margin-bottom: 10px; }
-.count-btn {
-  flex: 1; padding: 7px; border: 1px solid var(--border); border-radius: 8px;
-  background: transparent; color: var(--muted); font-size: 13px; font-weight: 600; cursor: pointer;
-}
-.count-btn.active { border-color: var(--accent); color: var(--accent); background: rgba(139,92,246,0.1); }
+/* ── テーマ入力 ── */
+.theme-wrap { margin-bottom: 18px; }
 .theme-input {
-  width: 100%; padding: 9px 10px;
-  background: var(--card2); border: 1px solid var(--border); border-radius: 8px;
-  color: var(--text); font-size: 13px; font-family: inherit; margin-bottom: 10px;
+  width: 100%;
+  padding: 12px 14px;
+  background: var(--surface);
+  border: 1.5px solid var(--border);
+  border-radius: 12px;
+  color: var(--text);
+  font-size: 15px;
+  outline: none;
+  transition: border-color 0.15s;
+  -webkit-appearance: none;
 }
-.theme-input:focus { outline: none; border-color: var(--accent); }
+.theme-input:focus { border-color: var(--accent); }
 .theme-input::placeholder { color: var(--muted); }
 
-/* ── カード ── */
-.card {
-  background: var(--card); border: 1px solid var(--border); border-radius: 14px;
-  padding: 13px; margin-bottom: 10px; transition: border-color 0.2s;
+/* ── 件数セレクタ ── */
+.count-wrap { margin-bottom: 20px; }
+.count-row { display: flex; gap: 8px; }
+.count-btn {
+  flex: 1; padding: 10px;
+  background: var(--surface);
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  color: var(--muted); font-size: 14px; font-weight: 700;
+  cursor: pointer; transition: all 0.15s;
 }
-.card.editing { border-color: var(--accent); }
-.card-meta {
-  display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px;
-}
-.card-left { display: flex; align-items: center; gap: 6px; }
-.platform-badge {
-  font-size: 10px; font-weight: 700; padding: 2px 7px; border-radius: 5px;
-  text-transform: uppercase;
-}
-.pb-x        { background: rgba(29,161,242,0.15); color: #60a5fa; }
-.pb-instagram { background: rgba(225,48,108,0.15); color: #f472b6; }
-.pb-note     { background: rgba(16,185,129,0.15); color: var(--green); }
-.pb-tiktok   { background: rgba(239,68,68,0.15); color: var(--red); }
-.manual-tag {
-  font-size: 9px; padding: 1px 5px; border-radius: 4px;
-  background: rgba(245,158,11,0.15); color: var(--yellow); font-weight: 600;
+.count-btn.active {
+  background: var(--accent-glow);
+  border-color: var(--accent);
+  color: var(--accent-light);
 }
 
-/* スケジュール時刻（タップで変更） */
-.card-time {
-  font-size: 11px; color: var(--muted); cursor: pointer;
-  padding: 3px 6px; border-radius: 6px; transition: background 0.15s;
+/* ── 生成ボタン ── */
+.gen-btn {
+  width: 100%; padding: 16px;
+  background: linear-gradient(135deg, var(--accent), #5b21b6);
+  border: none; border-radius: 14px;
+  color: white; font-size: 16px; font-weight: 800;
+  cursor: pointer; letter-spacing: 0.03em;
+  display: flex; align-items: center; justify-content: center; gap: 8px;
+  transition: opacity 0.2s, transform 0.1s;
+  margin-bottom: 24px;
+  box-shadow: 0 4px 20px var(--accent-glow);
 }
-.card-time:hover, .card-time:active { background: var(--card2); }
-.time-picker {
-  font-size: 12px; background: var(--card2); border: 1px solid var(--accent);
-  border-radius: 7px; color: var(--text); padding: 4px 7px; width: 100%;
-  margin: 4px 0;
+.gen-btn:active { opacity: 0.85; transform: scale(0.98); }
+.gen-btn:disabled { opacity: 0.4; cursor: not-allowed; transform: none; }
+.gen-btn .spinner {
+  width: 18px; height: 18px;
+  border: 2px solid rgba(255,255,255,0.3);
+  border-top-color: white;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  display: none;
 }
-.time-picker:focus { outline: none; }
+.gen-btn.loading .spinner { display: block; }
+.gen-btn.loading .btn-icon { display: none; }
 
-.card-text {
-  font-size: 14px; line-height: 1.65; white-space: pre-wrap;
-  word-break: break-word; min-height: 30px;
-}
+/* ── 結果エリア ── */
+.results { display: flex; flex-direction: column; gap: 14px; }
 
-/* 文字数バー */
-.char-bar-wrap { margin: 8px 0 6px; }
-.char-bg { height: 3px; background: var(--border); border-radius: 2px; overflow: hidden; }
-.char-bar { height: 100%; border-radius: 2px; transition: width 0.2s, background 0.2s; }
-.char-ct {
-  font-size: 11px; color: var(--muted); margin-top: 3px; text-align: right;
-  font-variant-numeric: tabular-nums;
+/* ── 投稿カード ── */
+.post-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  overflow: hidden;
+  animation: slideIn 0.25s ease-out;
 }
-.char-ct.warn { color: var(--yellow); }
-.char-ct.over { color: var(--red); }
-
-/* カードアクション */
-.card-actions { display: flex; gap: 6px; margin-top: 8px; flex-wrap: wrap; }
-.btn {
-  padding: 8px 6px; border: none; border-radius: 8px;
-  font-size: 12px; font-weight: 600; cursor: pointer; transition: opacity 0.15s;
-  flex: 1; min-width: 50px; text-align: center;
+@keyframes slideIn {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
-.btn:active { opacity: 0.7; }
-.btn-edit   { background: var(--card2); color: var(--text); }
-.btn-post   { background: var(--accent); color: white; }
-.btn-delete { background: rgba(239,68,68,0.12); color: var(--red); }
-.btn-copy   { background: rgba(59,130,246,0.12); color: var(--blue); }
-.btn-save   { background: var(--green); color: white; }
-.btn-cancel { background: var(--card2); color: var(--muted); }
-.btn-done   { background: rgba(16,185,129,0.15); color: var(--green); font-size: 11px; padding: 5px 10px; flex: 0; }
-
-.edit-area {
-  width: 100%; background: var(--card2); border: 1px solid var(--accent);
-  border-radius: 10px; color: var(--text); font-size: 14px; line-height: 1.65;
-  padding: 9px; resize: vertical; min-height: 90px; font-family: inherit;
+.post-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px 8px;
+  border-bottom: 1px solid var(--border);
 }
-.edit-area:focus { outline: none; }
-
-/* ── FAB（手動追加） ── */
-.fab {
-  position: fixed;
-  bottom: calc(20px + var(--safe-bottom));
-  right: 18px;
-  width: 52px; height: 52px;
-  background: linear-gradient(135deg, var(--accent), var(--accent2));
-  color: white; border: none; border-radius: 50%;
-  font-size: 24px; cursor: pointer; z-index: 300;
-  box-shadow: 0 4px 16px rgba(139,92,246,0.5);
-  display: flex; align-items: center; justify-content: center;
-  transition: transform 0.2s;
+.post-num { font-size: 11px; font-weight: 700; color: var(--muted); }
+.char-badge {
+  font-size: 11px; font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(16,185,129,0.15);
+  color: var(--green);
 }
-.fab:active { transform: scale(0.9); }
-
-/* ── ボトムシート（手動追加） ── */
-.sheet-overlay {
-  position: fixed; inset: 0; background: rgba(0,0,0,0.6);
-  z-index: 400; opacity: 0; pointer-events: none; transition: opacity 0.25s;
+.char-badge.warn { background: rgba(245,158,11,0.15); color: #f59e0b; }
+.char-badge.over { background: rgba(239,68,68,0.15); color: #ef4444; }
+.post-text {
+  padding: 14px;
+  font-size: 15px; line-height: 1.7;
+  white-space: pre-wrap; word-break: break-word;
+  color: var(--text);
+  border: none; outline: none;
+  background: transparent;
+  width: 100%;
+  resize: none;
+  min-height: 80px;
+  font-family: inherit;
 }
-.sheet-overlay.open { opacity: 1; pointer-events: all; }
-.sheet {
-  position: fixed;
-  bottom: 0; left: 0; right: 0;
-  background: var(--card);
-  border-radius: 20px 20px 0 0;
-  padding: 0 16px calc(20px + var(--safe-bottom));
-  z-index: 500;
-  transform: translateY(100%);
-  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
-  max-height: 90vh; overflow-y: auto;
+.post-actions {
+  display: flex;
+  gap: 8px;
+  padding: 0 14px 12px;
 }
-.sheet.open { transform: translateY(0); }
-.sheet-handle {
-  width: 36px; height: 4px; background: var(--border);
-  border-radius: 2px; margin: 10px auto 14px;
+.copy-btn {
+  flex: 1; padding: 10px;
+  background: var(--accent-glow);
+  border: 1.5px solid var(--accent);
+  border-radius: 10px;
+  color: var(--accent-light); font-size: 13px; font-weight: 700;
+  cursor: pointer; transition: all 0.15s;
+  display: flex; align-items: center; justify-content: center; gap: 5px;
 }
-.sheet h2 { font-size: 16px; font-weight: 700; margin-bottom: 12px; }
-.platform-row { display: flex; gap: 6px; margin-bottom: 10px; }
-.plat-btn {
-  flex: 1; padding: 8px;
-  border: 1px solid var(--border); border-radius: 8px;
-  background: transparent; color: var(--muted); font-size: 12px; font-weight: 600; cursor: pointer;
+.copy-btn:active { opacity: 0.7; }
+.copy-btn.copied {
+  background: rgba(16,185,129,0.15);
+  border-color: var(--green);
+  color: var(--green);
 }
-.plat-btn.active { border-color: var(--accent); color: var(--accent); background: rgba(139,92,246,0.1); }
-.sheet-input {
-  width: 100%; padding: 9px 10px;
-  background: var(--card2); border: 1px solid var(--border); border-radius: 8px;
-  color: var(--text); font-size: 13px; font-family: inherit; margin-bottom: 8px;
+.regen-btn {
+  padding: 10px 14px;
+  background: var(--surface2);
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  color: var(--muted); font-size: 16px;
+  cursor: pointer; transition: all 0.15s;
 }
-.sheet-input:focus { outline: none; border-color: var(--accent); }
-.sheet-input::placeholder { color: var(--muted); }
-.datetime-label { font-size: 11px; color: var(--muted); font-weight: 600; margin-bottom: 5px; }
-.add-btn {
-  width: 100%; padding: 13px;
-  background: linear-gradient(135deg, var(--accent), var(--accent2));
-  color: white; border: none; border-radius: 12px;
-  font-size: 15px; font-weight: 700; cursor: pointer; margin-top: 8px;
-}
-.add-btn:active { opacity: 0.8; }
+.regen-btn:active { opacity: 0.7; }
 
 /* ── 空状態 ── */
 .empty {
-  text-align: center; color: var(--muted); padding: 50px 20px; font-size: 14px;
+  text-align: center;
+  padding: 48px 24px;
+  color: var(--muted);
 }
-.empty .icon { font-size: 40px; margin-bottom: 10px; }
+.empty-icon { font-size: 48px; margin-bottom: 12px; opacity: 0.6; }
+.empty-text { font-size: 14px; line-height: 1.6; }
 
 /* ── トースト ── */
 .toast {
-  position: fixed; bottom: calc(80px + var(--safe-bottom));
-  left: 50%; transform: translateX(-50%) translateY(20px);
-  background: var(--card2); color: var(--text);
-  border: 1px solid var(--border); border-radius: 10px;
-  padding: 9px 18px; font-size: 13px; font-weight: 600;
-  opacity: 0; transition: all 0.3s; z-index: 999; white-space: nowrap;
-  pointer-events: none;
+  position: fixed;
+  bottom: calc(24px + var(--safe-bottom));
+  left: 50%; transform: translateX(-50%) translateY(10px);
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 10px 20px;
+  border-radius: 999px;
+  font-size: 13px; font-weight: 600;
+  white-space: nowrap;
+  opacity: 0; transition: all 0.2s;
+  pointer-events: none; z-index: 999;
 }
 .toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
-.toast.ok  { border-color: var(--green); color: var(--green); }
-.toast.err { border-color: var(--red);   color: var(--red);   }
+.toast.ok { border-color: var(--green); color: var(--green); }
+.toast.err { border-color: #ef4444; color: #ef4444; }
 
-/* ── ローディング ── */
-.spin {
-  display: inline-block; width: 13px; height: 13px;
-  border: 2px solid rgba(255,255,255,0.3); border-top-color: white;
-  border-radius: 50%; animation: spin 0.6s linear infinite; vertical-align: middle;
-}
 @keyframes spin { to { transform: rotate(360deg); } }
-
-.section-lbl {
-  font-size: 10px; font-weight: 700; color: var(--muted);
-  text-transform: uppercase; letter-spacing: 1px; margin: 4px 0 8px;
-}
 </style>
 </head>
 <body>
 
-<!-- ヘッダー -->
 <div class="header">
-  <div class="header-row">
-    <h1>🎤 <span>kazuto</span> 投稿管理</h1>
-    <button class="refresh-btn" onclick="loadQueue()" title="更新">↻</button>
-  </div>
-  <div class="badges">
-    <span class="badge badge-p" id="badge-p">pending 0</span>
-    <span class="badge badge-d" id="badge-d">済 0</span>
+  <div class="header-icon">🎤</div>
+  <div>
+    <div class="header-title">kazuto 投稿ジェネレーター</div>
+    <div class="header-sub">ColorSing配信者 / ライバー事務所代表</div>
   </div>
 </div>
 
-<!-- タブ -->
-<div class="tabs">
-  <div class="tab active" data-tab="pending" onclick="switchTab('pending')">未投稿</div>
-  <div class="tab" data-tab="posted"  onclick="switchTab('posted')">投稿済</div>
-</div>
+<div class="main">
 
-<!-- フィルタ -->
-<div class="filter-row" id="filter-row">
-  <button class="chip active" data-plat="all" onclick="setFilter('all')">すべて</button>
-  <button class="chip" data-plat="x"         onclick="setFilter('x')">X</button>
-  <button class="chip" data-plat="instagram" onclick="setFilter('instagram')">Instagram</button>
-  <button class="chip" data-plat="note"      onclick="setFilter('note')">note</button>
-</div>
+  <!-- 時間帯 -->
+  <div class="section-label">時間帯</div>
+  <div class="slot-grid">
+    <button class="slot-btn" data-slot="朝"    onclick="selectSlot(this)">☀️<span class="slot-time">07:00</span></button>
+    <button class="slot-btn" data-slot="昼"    onclick="selectSlot(this)">🌤<span class="slot-time">12:00</span></button>
+    <button class="slot-btn" data-slot="夕方"  onclick="selectSlot(this)">🌇<span class="slot-time">17:00</span></button>
+    <button class="slot-btn" data-slot="夜"    onclick="selectSlot(this)">🌙<span class="slot-time">21:00</span></button>
+    <button class="slot-btn" data-slot="深夜"  onclick="selectSlot(this)">⭐<span class="slot-time">23:00</span></button>
+  </div>
 
-<div class="container">
+  <!-- テーマ -->
+  <div class="theme-wrap">
+    <div class="section-label">テーマ（任意）</div>
+    <input id="theme" class="theme-input" type="text"
+      placeholder="例：新曲に挑戦、ライバー募集、コーヒー…"
+      maxlength="50">
+  </div>
 
-  <!-- 生成エリア -->
-  <div class="gen-area">
-    <div class="gen-row">
-      <button class="gen-main" id="gen-btn" onclick="doGenerate()">
-        <span id="gen-icon">✨</span>
-        <span id="gen-label">投稿を生成</span>
-      </button>
-      <button class="gen-opts-btn" onclick="toggleGenPanel()" title="生成オプション">⚙</button>
-    </div>
-    <div class="gen-panel" id="gen-panel">
-      <label>生成件数</label>
-      <div class="count-row">
-        <button class="count-btn" data-n="1" onclick="selCount(1)">1件</button>
-        <button class="count-btn active" data-n="3" onclick="selCount(3)">3件</button>
-        <button class="count-btn" data-n="5" onclick="selCount(5)">5件</button>
-      </div>
-      <label>テーマ・指示（任意）</label>
-      <input class="theme-input" id="gen-theme" type="text"
-             placeholder="例: 今夜の配信告知、コラボ募集、音楽論…">
+  <!-- 件数 -->
+  <div class="count-wrap">
+    <div class="section-label">生成件数</div>
+    <div class="count-row">
+      <button class="count-btn active" data-count="1" onclick="selectCount(this)">1件</button>
+      <button class="count-btn" data-count="3" onclick="selectCount(this)">3件</button>
+      <button class="count-btn" data-count="5" onclick="selectCount(this)">5件</button>
     </div>
   </div>
 
-  <!-- 未投稿リスト -->
-  <div id="tab-pending">
-    <div class="section-lbl">未投稿の投稿文</div>
-    <div id="list-pending"></div>
-  </div>
+  <!-- 生成ボタン -->
+  <button class="gen-btn" id="genBtn" onclick="generate()">
+    <span class="spinner"></span>
+    <span class="btn-icon">✨</span>
+    投稿文を生成する
+  </button>
 
-  <!-- 投稿済リスト -->
-  <div id="tab-posted" style="display:none">
-    <div class="section-lbl">投稿済（直近30件）</div>
-    <div id="list-posted"></div>
+  <!-- 結果 -->
+  <div id="results" class="results">
+    <div class="empty">
+      <div class="empty-icon">🎵</div>
+      <div class="empty-text">時間帯を選んで<br>「生成」ボタンを押してください</div>
+    </div>
   </div>
 
 </div>
 
-<!-- 手動追加 FAB -->
-<button class="fab" onclick="openSheet()" title="手動で追加">＋</button>
-
-<!-- ボトムシート -->
-<div class="sheet-overlay" id="overlay" onclick="closeSheet()"></div>
-<div class="sheet" id="sheet">
-  <div class="sheet-handle"></div>
-  <h2>✏️ 投稿文を手動追加</h2>
-
-  <div class="platform-row">
-    <button class="plat-btn active" data-p="x"         onclick="selPlat('x')">X</button>
-    <button class="plat-btn" data-p="instagram"        onclick="selPlat('instagram')">Instagram</button>
-    <button class="plat-btn" data-p="note"             onclick="selPlat('note')">note</button>
-  </div>
-
-  <textarea class="edit-area" id="add-text"
-            placeholder="ここに投稿文を入力…"
-            oninput="updateAddBar()"></textarea>
-  <div class="char-bar-wrap">
-    <div class="char-bg"><div class="char-bar" id="add-bar"></div></div>
-    <div class="char-ct" id="add-ct">0 / 140文字</div>
-  </div>
-
-  <div class="datetime-label">投稿予定日時（省略=1時間後）</div>
-  <input class="sheet-input" type="datetime-local" id="add-time">
-
-  <button class="add-btn" onclick="addPost()">キューに追加する</button>
-</div>
-
-<!-- トースト -->
 <div class="toast" id="toast"></div>
 
 <script>
-// ── 状態 ─────────────────────────────────────────────────────
-let queue = [];
-let currentTab = 'pending';
-let filterPlat = 'all';
-let genCount = 3;
+let selectedSlot = '';
+let selectedCount = 1;
 
-// ── API ──────────────────────────────────────────────────────
-async function api(path, method = 'GET', body = null) {
-  const opts = { method, headers: { 'Content-Type': 'application/json' } };
-  if (body) opts.body = JSON.stringify(body);
+// 時間帯選択
+function selectSlot(btn) {
+  document.querySelectorAll('.slot-btn').forEach(b => b.classList.remove('active'));
+  btn.classList.add('active');
+  selectedSlot = btn.dataset.slot;
+}
+
+// 件数選択
+function selectCount(btn) {
+  document.querySelectorAll('.count-btn').forEach(b => b.classList.remove('active'));
+  btn.classList.add('active');
+  selectedCount = parseInt(btn.dataset.count);
+}
+
+// 生成
+async function generate() {
+  const btn = document.getElementById('genBtn');
+  btn.disabled = true;
+  btn.classList.add('loading');
+
+  const theme = document.getElementById('theme').value.trim();
+
   try {
-    const r = await fetch(path, opts);
-    return r.json();
+    const res = await fetch('/api/generate', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Basic ' + btoa(':' + getPassword()),
+      },
+      body: JSON.stringify({ count: selectedCount, slot: selectedSlot, theme }),
+    });
+    const data = await res.json();
+
+    if (data.ok && data.posts && data.posts.length) {
+      renderPosts(data.posts);
+    } else {
+      toast(data.error || '生成に失敗しました', 'err');
+    }
   } catch(e) {
-    return { error: String(e) };
+    toast('通信エラーが発生しました', 'err');
+  } finally {
+    btn.disabled = false;
+    btn.classList.remove('loading');
   }
 }
 
-// ── トースト ─────────────────────────────────────────────────
-function toast(msg, type = 'ok') {
+// 1件だけ再生成して指定カードを更新
+async function regenerateOne(idx) {
+  const theme = document.getElementById('theme').value.trim();
+  const card = document.querySelectorAll('.post-card')[idx];
+  if (!card) return;
+
+  const regenBtn = card.querySelector('.regen-btn');
+  regenBtn.textContent = '⌛';
+  regenBtn.disabled = true;
+
+  try {
+    const res = await fetch('/api/generate', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Basic ' + btoa(':' + getPassword()),
+      },
+      body: JSON.stringify({ count: 1, slot: selectedSlot, theme }),
+    });
+    const data = await res.json();
+    if (data.ok && data.posts && data.posts[0]) {
+      const ta = card.querySelector('.post-text');
+      ta.value = data.posts[0];
+      updateCharBadge(card);
+      toast('再生成しました ✓', 'ok');
+    } else {
+      toast(data.error || '再生成に失敗', 'err');
+    }
+  } catch(e) {
+    toast('通信エラー', 'err');
+  } finally {
+    regenBtn.textContent = '🔄';
+    regenBtn.disabled = false;
+  }
+}
+
+// 結果表示
+function renderPosts(posts) {
+  const el = document.getElementById('results');
+  el.innerHTML = '';
+  posts.forEach((text, i) => {
+    const card = document.createElement('div');
+    card.className = 'post-card';
+    card.innerHTML = `
+      <div class="post-card-header">
+        <span class="post-num">投稿 ${i + 1}</span>
+        <span class="char-badge" id="badge-${i}">${text.length} / 140文字</span>
+      </div>
+      <textarea class="post-text" id="text-${i}" oninput="onTextInput(this, ${i})">${escHtml(text)}</textarea>
+      <div class="post-actions">
+        <button class="copy-btn" onclick="copyPost(${i}, this)">📋 コピー</button>
+        <button class="regen-btn" onclick="regenerateOne(${i})">🔄</button>
+      </div>
+    `;
+    el.appendChild(card);
+    updateCharBadge(card);
+    autoResize(card.querySelector('.post-text'));
+  });
+}
+
+// テキスト編集時
+function onTextInput(ta, idx) {
+  const card = ta.closest('.post-card');
+  updateCharBadge(card);
+  autoResize(ta);
+}
+
+function updateCharBadge(card) {
+  const ta = card.querySelector('.post-text');
+  const badge = card.querySelector('.char-badge');
+  const n = ta.value.length;
+  badge.textContent = `${n} / 140文字`;
+  badge.className = 'char-badge' + (n > 140 ? ' over' : n > 126 ? ' warn' : '');
+}
+
+function autoResize(ta) {
+  ta.style.height = 'auto';
+  ta.style.height = ta.scrollHeight + 'px';
+}
+
+// コピー
+async function copyPost(idx, btn) {
+  const ta = document.getElementById('text-' + idx);
+  if (!ta) return;
+  try {
+    await navigator.clipboard.writeText(ta.value);
+  } catch(e) {
+    const range = document.createRange();
+    range.selectNodeContents(ta);
+    window.getSelection().removeAllRanges();
+    window.getSelection().addRange(range);
+    document.execCommand('copy');
+    window.getSelection().removeAllRanges();
+  }
+  btn.textContent = '✓ コピーしました';
+  btn.classList.add('copied');
+  toast('コピーしました ✓', 'ok');
+  setTimeout(() => {
+    btn.textContent = '📋 コピー';
+    btn.classList.remove('copied');
+  }, 2000);
+}
+
+// トースト
+function toast(msg, type) {
   const el = document.getElementById('toast');
   el.textContent = msg;
-  el.className = 'toast show ' + type;
-  setTimeout(() => el.className = 'toast', 2600);
+  el.className = 'toast show' + (type ? ' ' + type : '');
+  setTimeout(() => { el.className = 'toast'; }, 2200);
 }
 
-// ── ユーティリティ ────────────────────────────────────────────
-function esc(s) {
+// パスワード（Basic Auth用）
+function getPassword() {
+  let p = sessionStorage.getItem('pwd') || '';
+  if (!p) {
+    p = prompt('パスワードを入力してください') || '';
+    sessionStorage.setItem('pwd', p);
+  }
+  return p;
+}
+
+function escHtml(s) {
   return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
 }
-function maxLen(platform) {
-  return platform === 'x' ? 140 : platform === 'note' ? 5000 : 2200;
-}
-function charColor(n, max) {
-  return n > max ? 'var(--red)' : n > max * 0.9 ? 'var(--yellow)' : 'var(--green)';
-}
-function fmtTime(iso) {
-  if (!iso) return '';
-  const d = new Date(iso);
-  return d.toLocaleDateString('ja-JP', { month:'numeric', day:'numeric', weekday:'short' })
-    + ' ' + d.toTimeString().slice(0,5);
-}
-function toLocalDT(iso) {
-  if (!iso) return '';
-  // datetime-local input 用に "YYYY-MM-DDTHH:MM" へ変換
-  const d = new Date(iso);
-  const pad = n => String(n).padStart(2,'0');
-  return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
-}
-function safeId(id) { return id.replace(/[:.+]/g,'-'); }
 
-// ── キュー読み込み ─────────────────────────────────────────────
-async function loadQueue() {
-  const res = await api('/api/queue');
-  if (Array.isArray(res)) {
-    queue = res;
-    renderAll();
-  } else {
-    toast('読み込みエラー', 'err');
-  }
-}
+// 現在時刻から時間帯を自動選択
+(function autoSelectSlot() {
+  const h = new Date().getHours();
+  let slot;
+  if (h >= 5 && h < 10)       slot = '朝';
+  else if (h >= 10 && h < 15) slot = '昼';
+  else if (h >= 15 && h < 19) slot = '夕方';
+  else if (h >= 19 && h < 22) slot = '夜';
+  else                         slot = '深夜';
 
-// ── タブ・フィルタ ─────────────────────────────────────────────
-function switchTab(tab) {
-  currentTab = tab;
-  document.querySelectorAll('.tab').forEach(t => t.classList.toggle('active', t.dataset.tab === tab));
-  document.getElementById('tab-pending').style.display = tab === 'pending' ? '' : 'none';
-  document.getElementById('tab-posted').style.display  = tab === 'posted'  ? '' : 'none';
-}
-function setFilter(plat) {
-  filterPlat = plat;
-  document.querySelectorAll('.chip').forEach(c => c.classList.toggle('active', c.dataset.plat === plat));
-  renderAll();
-}
-
-// ── レンダリング ──────────────────────────────────────────────
-function renderAll() {
-  let pending = queue.filter(q => q.status === 'pending');
-  let posted  = queue.filter(q => q.status === 'posted')
-                     .sort((a,b)=>(b.posted_at||'').localeCompare(a.posted_at||'')).slice(0,30);
-
-  if (filterPlat !== 'all') {
-    pending = pending.filter(q => (q.platform||'x') === filterPlat);
-    posted  = posted.filter(q => (q.platform||'x') === filterPlat);
-  }
-  pending.reverse(); // 新しいものを上に
-
-  document.getElementById('badge-p').textContent = `pending ${pending.length}`;
-  document.getElementById('badge-d').textContent = `済 ${posted.length}`;
-
-  document.getElementById('list-pending').innerHTML =
-    pending.length ? pending.map(q => cardHTML(q, false)).join('') :
-    `<div class="empty"><div class="icon">📭</div>未投稿の投稿文はありません<br>＋ボタンで手動追加、または「生成」で自動作成できます</div>`;
-
-  document.getElementById('list-posted').innerHTML =
-    posted.length ? posted.map(q => cardHTML(q, true)).join('') :
-    `<div class="empty"><div class="icon">📬</div>投稿済の記録はありません</div>`;
-}
-
-function cardHTML(item, readOnly) {
-  const id  = item._id || item.created_at;
-  const sid = safeId(id);
-  const plat = (item.platform || 'x').toLowerCase();
-  const text = item.text || '';
-  const max  = maxLen(plat);
-  const n    = text.length;
-  const cc   = charColor(n, max);
-  const pct  = Math.min(100, Math.round(n/max*100)) + '%';
-  const timeLabel = item.posted_at ? `投稿済 ${fmtTime(item.posted_at)}`
-                                   : fmtTime(item.scheduled_for) || '時刻未設定';
-  const manualTag = item.manually_added ? '<span class="manual-tag">手動</span>' : '';
-
-  const actions = readOnly ? '' : `
-    <div class="card-actions">
-      <button class="btn btn-edit"   onclick="startEdit('${id}')">編集</button>
-      <button class="btn btn-copy"   onclick="copyText('${id}')">コピー</button>
-      <button class="btn btn-post"   onclick="postNow('${id}',this)">投稿する</button>
-      <button class="btn btn-delete" onclick="delPost('${id}')">削除</button>
-    </div>`;
-
-  return `
-<div class="card" id="card-${sid}">
-  <div class="card-meta">
-    <div class="card-left">
-      <span class="platform-badge pb-${plat}">${plat}</span>
-      ${manualTag}
-    </div>
-    <span class="card-time" id="time-${sid}" onclick="editTime('${id}')">${timeLabel}</span>
-  </div>
-  <div class="card-text" id="text-${sid}">${esc(text)}</div>
-  <div class="char-bar-wrap">
-    <div class="char-bg"><div class="char-bar" id="bar-${sid}" style="width:${pct};background:${cc}"></div></div>
-    <div class="char-ct ${n>max?'over':n>max*0.9?'warn':''}" id="ct-${sid}">${n} / ${max}文字</div>
-  </div>
-  ${actions}
-</div>`;
-}
-
-// ── 編集 ──────────────────────────────────────────────────────
-function startEdit(id) {
-  const sid  = safeId(id);
-  const item = queue.find(q=>(q._id||q.created_at)===id);
-  if (!item) return;
-  const card = document.getElementById('card-'+sid);
-  const textEl = document.getElementById('text-'+sid);
-  card.classList.add('editing');
-  textEl.outerHTML = `<textarea class="edit-area" id="ea-${sid}">${esc(item.text||'')}</textarea>`;
-  const ta = document.getElementById('ea-'+sid);
-  const max = maxLen(item.platform||'x');
-  function upd() {
-    const n = ta.value.length;
-    const b = document.getElementById('bar-'+sid);
-    const c = document.getElementById('ct-'+sid);
-    if (b) { b.style.width = Math.min(100,Math.round(n/max*100))+'%'; b.style.background = charColor(n,max); }
-    if (c) { c.textContent = `${n} / ${max}文字`; c.className = 'char-ct'+(n>max?' over':n>max*0.9?' warn':''); }
-  }
-  ta.addEventListener('input', upd); upd(); ta.focus();
-  card.querySelector('.card-actions').innerHTML = `
-    <button class="btn btn-save"   onclick="saveEdit('${id}')">保存</button>
-    <button class="btn btn-cancel" onclick="renderAll()">キャンセル</button>`;
-}
-
-async function saveEdit(id) {
-  const sid = safeId(id);
-  const ta  = document.getElementById('ea-'+sid);
-  if (!ta) return;
-  const res = await api('/api/edit','POST',{id,text:ta.value});
-  if (res.ok) {
-    const item = queue.find(q=>(q._id||q.created_at)===id);
-    if (item) item.text = ta.value;
-    toast('保存しました ✓');
-    renderAll();
-  } else { toast(res.error||'保存失敗','err'); }
-}
-
-// ── スケジュール変更 ───────────────────────────────────────────
-function editTime(id) {
-  const sid = safeId(id);
-  const item = queue.find(q=>(q._id||q.created_at)===id);
-  if (!item || item.status === 'posted') return;
-  const timeEl = document.getElementById('time-'+sid);
-  const current = toLocalDT(item.scheduled_for);
-  timeEl.outerHTML = `
-    <span style="display:flex;gap:4px;align-items:center" id="time-${sid}">
-      <input class="time-picker" type="datetime-local" id="dt-${sid}" value="${current}">
-      <button class="btn btn-done" onclick="saveTime('${id}')">確定</button>
-    </span>`;
-}
-async function saveTime(id) {
-  const sid = safeId(id);
-  const inp = document.getElementById('dt-'+sid);
-  if (!inp || !inp.value) return;
-  // datetime-local はローカル時刻 → ISO に変換
-  const localDT = new Date(inp.value);
-  const isoStr  = localDT.toISOString();
-  const res = await api('/api/reschedule','POST',{id, scheduled_for: isoStr});
-  if (res.ok) {
-    const item = queue.find(q=>(q._id||q.created_at)===id);
-    if (item) item.scheduled_for = isoStr;
-    toast('スケジュールを変更しました ✓');
-    renderAll();
-  } else { toast(res.error||'変更失敗','err'); }
-}
-
-// ── 投稿 ──────────────────────────────────────────────────────
-async function postNow(id, btn) {
-  if (!confirm('このツイートをXに今すぐ投稿しますか？')) return;
-  btn.disabled = true;
-  btn.innerHTML = '<span class="spin"></span>';
-  const res = await api('/api/post','POST',{id});
-  btn.disabled = false; btn.textContent = '投稿する';
-  if (res.ok) {
-    const item = queue.find(q=>(q._id||q.created_at)===id);
-    if (item) { item.status='posted'; item.posted_at=new Date().toISOString(); }
-    toast('投稿しました 🎤');
-    renderAll();
-  } else { toast(res.error||'投稿失敗','err'); }
-}
-
-// ── コピー ────────────────────────────────────────────────────
-function copyText(id) {
-  const item = queue.find(q=>(q._id||q.created_at)===id);
-  if (!item) return;
-  navigator.clipboard.writeText(item.text)
-    .then(()=>toast('コピーしました 📋'))
-    .catch(()=>toast('コピーに失敗しました','err'));
-}
-
-// ── 削除 ──────────────────────────────────────────────────────
-async function delPost(id) {
-  if (!confirm('この投稿文を削除しますか？')) return;
-  const res = await api('/api/delete','POST',{id});
-  if (res.ok) { queue=queue.filter(q=>(q._id||q.created_at)!==id); toast('削除しました'); renderAll(); }
-  else toast(res.error||'削除失敗','err');
-}
-
-// ── 生成 ──────────────────────────────────────────────────────
-function toggleGenPanel() {
-  document.getElementById('gen-panel').classList.toggle('open');
-}
-function selCount(n) {
-  genCount = n;
-  document.querySelectorAll('.count-btn').forEach(b => b.classList.toggle('active', +b.dataset.n===n));
-}
-async function doGenerate() {
-  const btn   = document.getElementById('gen-btn');
-  const icon  = document.getElementById('gen-icon');
-  const label = document.getElementById('gen-label');
-  const theme = document.getElementById('gen-theme').value.trim();
-  btn.disabled = true;
-  icon.innerHTML = '<span class="spin"></span>';
-  label.textContent = `${genCount}件生成中…`;
-  const res = await api('/api/generate','POST',{count:genCount, theme});
-  btn.disabled = false; icon.textContent='✨'; label.textContent='投稿を生成';
-  if (res.ok) { toast(`${res.count}件生成しました 🎵`); await loadQueue(); }
-  else toast(res.error||'生成失敗','err');
-}
-
-// ── ボトムシート（手動追加） ──────────────────────────────────
-let addPlat = 'x';
-function openSheet() {
-  document.getElementById('overlay').classList.add('open');
-  document.getElementById('sheet').classList.add('open');
-  document.getElementById('add-text').value = '';
-  document.getElementById('add-ct').textContent = '0 / 140文字';
-  document.getElementById('add-bar').style.width = '0%';
-  document.getElementById('add-time').value = '';
-}
-function closeSheet() {
-  document.getElementById('overlay').classList.remove('open');
-  document.getElementById('sheet').classList.remove('open');
-}
-function selPlat(p) {
-  addPlat = p;
-  document.querySelectorAll('.plat-btn').forEach(b => b.classList.toggle('active', b.dataset.p===p));
-  updateAddBar();
-}
-function updateAddBar() {
-  const ta  = document.getElementById('add-text');
-  const bar = document.getElementById('add-bar');
-  const ct  = document.getElementById('add-ct');
-  const n   = ta.value.length;
-  const max = maxLen(addPlat);
-  bar.style.width = Math.min(100,Math.round(n/max*100))+'%';
-  bar.style.background = charColor(n,max);
-  ct.textContent = `${n} / ${max}文字`;
-  ct.className = 'char-ct'+(n>max?' over':n>max*0.9?' warn':'');
-}
-async function addPost() {
-  const text = document.getElementById('add-text').value.trim();
-  const dtVal = document.getElementById('add-time').value;
-  if (!text) { toast('投稿文を入力してください','err'); return; }
-  const scheduled_for = dtVal ? new Date(dtVal).toISOString() : '';
-  const res = await api('/api/add','POST',{text, platform:addPlat, scheduled_for});
-  if (res.ok) {
-    closeSheet();
-    if (res.item) { res.item._id = res.item.created_at; queue.push(res.item); }
-    toast('追加しました ✓'); renderAll();
-  } else { toast(res.error||'追加失敗','err'); }
-}
-
-// ── 初期化 ────────────────────────────────────────────────────
-loadQueue();
-setInterval(loadQueue, 30000);
+  const btn = document.querySelector(`.slot-btn[data-slot="${slot}"]`);
+  if (btn) { btn.classList.add('active'); selectedSlot = slot; }
+})();
 </script>
 </body>
 </html>"""
 
+
+# ── ルーティング ──────────────────────────────────────────────────
 
 @app.route("/")
 @require_auth


### PR DESCRIPTION
## 変更内容

### 新機能：スマホ対応の投稿文ジェネレーター

時間帯を選んでボタンを押すだけで kazuto ペルソナの投稿文を生成し、コピーできるアプリ。
自動投稿なし・X API 不要。

### 主な変更

| ファイル | 変更内容 |
|---|---|
| `src/web_app.py` | 投稿文ジェネレーターに刷新（キュー管理・X投稿を削除） |
| `render.yaml` | 必要な env を `WEB_PASSWORD` + `ANTHROPIC_API_KEY` の2つだけに簡略化 |
| `persona/kazuto_config.yaml` | `history_file` フィールドを追加 |
| `src/main.py` | `--persona` オプションを追加（ペルソナ設定ファイルを指定可能に） |
| `src/platforms/base.py` | 全アダプターが `persona` kwarg を受け取れるよう対応 |
| `src/platforms/x.py` | ペルソナの `history_file` を参照してアカウントごとに履歴を分離 |
| `.github/workflows/kazuto_post.yml` | kazuto 用 1日5回自動投稿ワークフロー（手動投稿派はスキップ可） |

### アプリの使い方

1. 時間帯を選択（☀️朝 / 🌤昼 / 🌇夕方 / 🌙夜 / ⭐深夜）
2. テーマを任意入力
3. 件数を選択（1 / 3 / 5件）
4. 「投稿文を生成する」ボタンを押す
5. 生成されたテキストを編集 → 「📋 コピー」して X に貼り付け

### Render デプロイに必要な環境変数（2つだけ）

| 変数名 | 内容 |
|---|---|
| `WEB_PASSWORD` | アプリのログインパスワード |
| `ANTHROPIC_API_KEY` | Claude API キー |

---
_Generated by [Claude Code](https://claude.ai/code/session_01FytqxwptsWdbcP3YHMsVQG)_