### PR TITLE
fix: スマホで真っ白になる問題を修正

### DIFF
--- a/src/web_app.py
+++ b/src/web_app.py
@@ -37,9 +37,9 @@ def require_auth(f):
     def decorated(*args, **kwargs):
         if not _check_auth():
             return Response(
-                "認証が必要です",
+                "Unauthorized",
                 401,
-                {"WWW-Authenticate": 'Basic realm="kazuto投稿ジェネレーター"'},
+                {"WWW-Authenticate": 'Basic realm="kazuto-post-generator"'},
             )
         return f(*args, **kwargs)
     return decorated


### PR DESCRIPTION
## 修正内容

`WWW-Authenticate` ヘッダーの realm に日本語を使っていたため、gunicorn が無効なヘッダーと判断し、認証ダイアログが表示されずスマホで真っ白になっていた問題を修正。

**変更前:** `Basic realm="kazuto投稿ジェネレーター"`  
**変更後:** `Basic realm="kazuto-post-generator"`

---
_Generated by [Claude Code](https://claude.ai/code/session_01FytqxwptsWdbcP3YHMsVQG)_