### PR TITLE
/goods の販売商品をchacoデザインマグカップに更新

### DIFF
--- a/persona/goods_config.yaml
+++ b/persona/goods_config.yaml
@@ -7,7 +7,7 @@
 # description : 商品の説明文（任意、購入ページに表示）
 
 products:
-  - id: "sample-001"
-    name: "サンプル商品"
-    price: 3000
-    description: "ここに商品の説明を書いてください。販売したい商品に合わせて自由に編集・追加できます。"
+  - id: "chaco-mug-001"
+    name: "chacoデザインマグカップ"
+    price: 2190
+    description: "chacoデザインのオリジナルマグカップです（送料込み）。"


### PR DESCRIPTION
## Summary
- `/goods` の販売商品を「サンプル商品」から「chacoデザインマグカップ」（2,190円・送料込み）に更新
- 価格は本体1,000円＋消費税100円＋送料見積1,090円（郵便局ゆうパック サイズ60の全国平均）で算出

## Test plan
- [x] `_load_goods_products()` が正しく新商品データを読み込むことを確認
- [x] `/goods` ページのJSON埋め込みデータに商品名・価格(2190)が含まれることを確認
- [x] 旧サンプル商品の表示が消えていることを確認

https://claude.ai/code/session_01PaBrRwGGjiR7K5ZsqASHtm


---
_Generated by [Claude Code](https://claude.ai/code/session_01PaBrRwGGjiR7K5ZsqASHtm)_