### PR TITLE
TシャツS〜XL: 4,590円 / XXL: 5,590円 に価格修正（送料込み）

### DIFF
--- a/persona/goods_config.yaml
+++ b/persona/goods_config.yaml
@@ -20,15 +20,15 @@ products:
     variants:
       size:
         - label: "S"
-          price: 3500
+          price: 4590
         - label: "M"
-          price: 3500
+          price: 4590
         - label: "L"
-          price: 3500
+          price: 4590
         - label: "XL"
-          price: 3500
+          price: 4590
         - label: "XXL"
-          price: 4500
+          price: 5590
       color:
         - label: "チャコール"
         - label: "ホワイト"


### PR DESCRIPTION
## Summary
- Tシャツの価格を「税込本体価格＋送料1,090円」の合計に修正
- S/M/L/XL: 3,500円(税込) + 1,090円 = **4,590円**
- XXL: 4,500円(税込) + 1,090円 = **5,590円**

https://claude.ai/code/session_01PaBrRwGGjiR7K5ZsqASHtm


---
_Generated by [Claude Code](https://claude.ai/code/session_01PaBrRwGGjiR7K5ZsqASHtm)_