### PR TITLE
chacoデザインTシャツ 5.6oz を商品追加

### DIFF
--- a/persona/goods_config.yaml
+++ b/persona/goods_config.yaml
@@ -48,3 +48,23 @@ products:
       - path: "/static/goods/tshirt-white-small.webp"
         color: "ホワイト"
         design: "スモール"
+
+  - id: "chaco-tshirt-56-001"
+    name: "chacoデザインTシャツ 5.6oz"
+    description: "chacoオリジナルデザインの5.6ozTシャツ（送料込み）。\nカラー・デザイン・サイズをお選びください。"
+    variants:
+      size:
+        - label: "S"
+          price: 3590
+        - label: "M"
+          price: 3590
+        - label: "L"
+          price: 3590
+        - label: "XL"
+          price: 3590
+      color:
+        - label: "ホワイト"
+        - label: "黒"
+      design:
+        - label: "センター"
+        - label: "スモール"


### PR DESCRIPTION
## Summary
- chacoデザインTシャツ 5.6oz を新規追加
- S/M/L/XL 均一: 2,500円(税込) + 送料1,090円 = **3,590円**
- カラー: ホワイト / 黒、デザイン: センター / スモール
- 商品写真は後で追加予定（現在はアイコン表示）

https://claude.ai/code/session_01PaBrRwGGjiR7K5ZsqASHtm


---
_Generated by [Claude Code](https://claude.ai/code/session_01PaBrRwGGjiR7K5ZsqASHtm)_