### PR TITLE
面談予約アプリ: /availability にパスワード保護を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,8 @@ kazuto と あまりん/さな/しー/かぴのすけ の4ペアそれぞれに�
 `eternal-interview-booking` としてホスト（`render.yaml` 参照）。
 
 ### 仕組み
-- ログイン不要。5人は `/availability` で自分の名前を選んで空き時間（1時間単位、9:00〜22:00）を登録する。
+- `/availability`（空き時間登録）はパスワード保護（`AVAILABILITY_PASSWORD`、未設定時のデフォルト: `ETERNALLOVE`）。5人はログイン後、自分の名前を選んで空き時間（1時間単位、9:00〜22:00）を登録する。
+- `/book/<slug>`（外部ゲスト向け予約ページ）はログイン不要・一般公開。
 - 各ペアの予約ページ（`/book/<slug>`）には、kazuto とそのメンバー両方が空けている時間だけが表示される。
 - ゲストは名前だけ入力して予約。**先着順**で、同じスロットは一度しか予約できない。
 - kazuto は全ペア共通の参加者なので、1ペアで埋まると他のペアの同時刻も自動的に予約不可になる。
@@ -117,8 +118,8 @@ kazuto と あまりん/さな/しー/かぴのすけ の4ペアそれぞれに�
 
 ### URL
 - `/` — メニュー（空き時間登録 + 4人分の予約リンク）
-- `/availability` — 空き時間登録（5人共通、ログイン不要）
-- `/book/amarin` `/book/sana` `/book/shi` `/book/kapinosuke` — 各メンバーとの面談予約ページ（一般公開）
+- `/availability` — 空き時間登録（5人共通、パスワード保護）
+- `/book/amarin` `/book/sana` `/book/shi` `/book/kapinosuke` — 各メンバーとの面談予約ページ（一般公開・ログイン不要）
 
 ### データ
 - `posts/booking_availability.json` — 各人の空き時間（`DATABASE_URL` 設定時は Postgres の `booking_availability` テーブル）

--- a/render.yaml
+++ b/render.yaml
@@ -40,6 +40,8 @@ services:
     envVars:
       - key: FLASK_SECRET_KEY
         sync: false          # セッション用秘密鍵（任意の文字列）
+      - key: AVAILABILITY_PASSWORD
+        sync: false          # /availability ログインパスワード（未設定時のデフォルト: ETERNALLOVE）
       - key: DATABASE_URL
         sync: false          # Supabase の接続 URI（任意。未設定時はファイルに保存）
       - key: GOOGLE_SERVICE_ACCOUNT_JSON

--- a/src/booking_app.py
+++ b/src/booking_app.py
@@ -24,12 +24,14 @@ import uuid
 from pathlib import Path
 from datetime import datetime, timedelta, timezone
 
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, session
 
 sys.path.insert(0, str(Path(__file__).parent))
 
 app = Flask(__name__)
 app.secret_key = os.environ.get("FLASK_SECRET_KEY", os.urandom(24))
+
+AVAILABILITY_PASSWORD = os.environ.get("AVAILABILITY_PASSWORD", "ETERNALLOVE")
 
 ADMIN = "kazuto"
 MEMBER_SLUGS = {
@@ -331,10 +333,38 @@ def pair_open_slots(member_name):
     return person_available_slots(ADMIN) & person_available_slots(member_name) - booked_slots()
 
 
+# ── 認証（空き時間登録ページ） ───────────────────────────────────
+
+def is_avail_authed():
+    return bool(session.get("avail_ok"))
+
+
+@app.route("/api/availability/me")
+def api_availability_me():
+    return jsonify({"authed": is_avail_authed()})
+
+
+@app.route("/api/availability/login", methods=["POST"])
+def api_availability_login():
+    data = request.get_json(force=True)
+    if data.get("password") == AVAILABILITY_PASSWORD:
+        session["avail_ok"] = True
+        return jsonify({"ok": True})
+    return jsonify({"error": "パスワードが違います"}), 401
+
+
+@app.route("/api/availability/logout", methods=["POST"])
+def api_availability_logout():
+    session.pop("avail_ok", None)
+    return jsonify({"ok": True})
+
+
 # ── API: 空き時間登録 ────────────────────────────────────────────
 
 @app.route("/api/availability")
 def api_availability_get():
+    if not is_avail_authed():
+        return jsonify({"error": "unauthorized"}), 401
     person = request.args.get("person", "")
     date = request.args.get("date", "")
     if person not in ALL_PEOPLE or not date:
@@ -359,6 +389,8 @@ def api_availability_get():
 
 @app.route("/api/availability/toggle", methods=["POST"])
 def api_availability_toggle():
+    if not is_avail_authed():
+        return jsonify({"error": "unauthorized"}), 401
     data = request.get_json(force=True)
     person = data.get("person", "")
     date = data.get("date", "")
@@ -378,6 +410,8 @@ def api_availability_toggle():
 
 @app.route("/api/booking/<booking_id>/edit", methods=["POST"])
 def api_booking_edit(booking_id):
+    if not is_avail_authed():
+        return jsonify({"error": "unauthorized"}), 401
     data = request.get_json(force=True)
     guest_name = str(data.get("guest_name", "")).strip()
     if not guest_name:
@@ -405,6 +439,8 @@ def api_booking_edit(booking_id):
 
 @app.route("/api/booking/<booking_id>/delete", methods=["POST"])
 def api_booking_delete(booking_id):
+    if not is_avail_authed():
+        return jsonify({"error": "unauthorized"}), 401
     booking = delete_booking(booking_id)
     if not booking:
         return jsonify({"error": "予約が見つかりません"}), 404
@@ -629,6 +665,7 @@ AVAILABILITY_HTML = """<!DOCTYPE html>
     <div class="header-title">空き時間登録</div>
     <div class="header-sub">タップで空き時間をON/OFF</div>
   </div>
+  <button class="back-btn" onclick="doLogout()" title="ログアウト">🔒</button>
 </div>
 <div class="wrap">
   <select class="fi" id="f-person" onchange="onPersonChange()">__PERSON_OPTIONS__</select>
@@ -638,6 +675,17 @@ AVAILABILITY_HTML = """<!DOCTYPE html>
     <button class="day-btn" onclick="changeDay(1)">›</button>
   </div>
   <div class="hour-grid" id="hour-grid"></div>
+</div>
+
+<div class="overlay open" id="pw-overlay">
+  <div class="sheet">
+    <div class="handle"></div>
+    <div class="sheet-title">パスワードを入力してください</div>
+    <input type="password" class="fi" id="f-pw" placeholder="パスワード" onkeydown="if(event.key==='Enter')submitPw()">
+    <div class="btn-row">
+      <button class="btn-pri" style="width:100%" onclick="submitPw()">入る</button>
+    </div>
+  </div>
 </div>
 <div class="toast" id="toast"></div>
 <script>
@@ -719,8 +767,38 @@ async function deleteBooking(bookingId, hour, member) {
     else { toast(d.error || '削除に失敗しました'); }
   } catch(e) { toast('通信エラーが発生しました'); }
 }
+async function doLogout() {
+  await fetch('/api/availability/logout', { method: 'POST' });
+  location.reload();
+}
+async function checkAuth() {
+  try {
+    const d = await (await fetch('/api/availability/me')).json();
+    if (d.authed) {
+      document.getElementById('pw-overlay').classList.remove('open');
+      render();
+    }
+  } catch(e) {}
+}
+async function submitPw() {
+  const password = document.getElementById('f-pw').value;
+  try {
+    const r = await fetch('/api/availability/login', {
+      method: 'POST', headers: {'Content-Type':'application/json'},
+      body: JSON.stringify({ password }),
+    });
+    const d = await r.json();
+    if (d.ok) {
+      document.getElementById('pw-overlay').classList.remove('open');
+      render();
+    } else {
+      toast(d.error || 'パスワードが違います');
+      document.getElementById('f-pw').value = '';
+    }
+  } catch(e) { toast('通信エラーが発生しました'); }
+}
 __TOAST_JS__
-render();
+checkAuth();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## 変更内容
- `/availability` ページにパスワード保護を追加（`AVAILABILITY_PASSWORD` 環境変数、未設定時のデフォルトは `ETERNALLOVE`）
- パスワード入力前は空き時間データを取得・編集できないよう、関連API（`/api/availability` 取得・トグル・予約編集・予約削除）もサーバー側で401を返すようにガード
- ヘッダーにログアウトボタンを追加
- 外部ゲスト向けの `/book/<slug>` 予約ページとそのAPIは引き続きログイン不要・一般公開

## デプロイ後の確認
- Renderの環境変数に `AVAILABILITY_PASSWORD` を任意の値で設定すれば、その値がパスワードになります（未設定ならデフォルトの `ETERNALLOVE` が使われます）

## テスト
- ローカルでFlaskテストクライアントを使い、未ログイン時の401、誤ったパスワードでの401、正しいパスワードでのログイン成功、ログイン後のAPIアクセス、ログアウト後の再ブロック、`/book/<slug>` が引き続き公開のままであることを確認済み


---
_Generated by [Claude Code](https://claude.ai/code/session_015YiDwYukWU3tpPouViBPr5)_